### PR TITLE
add hyperlink to the lesson for python on the day 1 schedule

### DIFF
--- a/_includes/sc/schedule.html
+++ b/_includes/sc/schedule.html
@@ -8,7 +8,7 @@
       <tr> <td>09:00</td>  <td> <a href="http://swcarpentry.github.io/shell-novice"> Automating tasks with the Unix shell </a> </td> </tr>
       <tr> <td>10:30</td>  <td>Morning break</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Building Programs with Python</td> </tr>
+      <tr> <td>13:00</td>  <td> <a href="https://uw-madison-datascience.github.io/python-novice-gapminder-custom/"> Building Programs with Python </a></td> </tr>
       <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
       <tr> <td>16:30</td>  <td>END</td> </tr>


### PR DESCRIPTION
Unless I am mistaken, I think both sections are using the same lesson "python-novice-gapminder-custom"; the day one entry on the schedule was missing the hyperlink.